### PR TITLE
ci: rearrange release steps to fix missing git config author

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,9 @@ jobs:
         with:
           node-version: lts/*
 
+      - name: Setup Flutter
+        uses: ./.github/actions/flutter-setup/action1.yml
+
       - name: Cache node_modules
         id: node-modules
         uses: actions/cache@v4
@@ -61,16 +64,14 @@ jobs:
           echo "name:        ${{ steps.import-gpg.outputs.name }}"
           echo "email:       ${{ steps.import-gpg.outputs.email }}"
 
+      - name: Install dependencies
+        run: npm i
+
       - name: git config
         run: |
           git config user.name "${{ steps.import-gpg.outputs.name }}"
           git config user.email "${{ steps.import-gpg.outputs.email }}"
-
-      - name: Setup Flutter
-        uses: ./.github/actions/flutter-setup
-
-      - name: Install dependencies
-        run: npm i
+          git config --list
 
       - name: Run release-it
         run: npx release-it ${{ github.event.inputs.input_version }} --ci


### PR DESCRIPTION
Somehow a step between the git config and the release-it step messes with the set git config.
It looks like its the flutter install workflow.
With these changes the git author and name is set right before release-it runs.
