### PR TITLE
ci: checkout git tag for flutter to be able to publish

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -7,7 +7,10 @@
             "npx auto-changelog -v ${version} -c .auto-changelog",
             "flutter pub publish --to-archive abrevva_${version}.tgz"
         ],
-        "before:github:release": "flutter pub publish --force"
+        "after:version:afterRelease": [
+            "git checkout refs/tags/${version}",
+            "flutter pub publish --force"
+        ]
     },
     "npm": {
         "skipChecks": true,


### PR DESCRIPTION
Fix error on publish:
`The calling GitHub Action is not allowed to publish, because: publishing is only allowed from 'tag' refType, this token has 'branch' refType. See https://dart.dev/go/publishing-from-github`
Docs here: https://dart.dev/tools/pub/automated-publishing#publishing-packages-using-github-actions