### PR TITLE
ci: separate release-it and pub.dev publish to comply with dev.pub settings

### DIFF
--- a/.github/pub.dev.yml
+++ b/.github/pub.dev.yml
@@ -1,0 +1,15 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write # Required for authentication using OIDC
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: 'pub.dev'
+      # working-directory: path/to/package/within/repository

--- a/.release-it.json
+++ b/.release-it.json
@@ -6,10 +6,6 @@
             "flutter pub get",
             "npx auto-changelog -v ${version} -c .auto-changelog",
             "flutter pub publish --to-archive abrevva_${version}.tgz"
-        ],
-        "after:version:afterRelease": [
-            "git checkout refs/tags/${version}",
-            "flutter pub publish --force"
         ]
     },
     "npm": {
@@ -20,13 +16,14 @@
     "git": {
         "commitMessage": "chore: release ${version}",
         "tagName": "${version}",
+        "tag": true,
         "commitArgs": [
             "-S"
         ],
         "tagArgs": [
             "-s"
         ],
-        "push": false
+        "push": true
     },
     "github": {
         "release": true,


### PR DESCRIPTION
dev.pub requires the trigger on the uploading workflow to be a tag.
Therefore we let release-it handle the git and release notes stuff and push the commit with the release tag.
The tag that is pushed to github triggers the dev.pub workflow that does only the upload to pub.dev.